### PR TITLE
Disable password check when navigating from index

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,6 +98,13 @@
     <div id="footer"></div>
     <script src="js/includehtml.js"></script>
     <script src="js/MoveAside.js"></script>
+    <script>
+        document.querySelectorAll('.profile table a').forEach((link) => {
+            link.addEventListener('click', () => {
+                sessionStorage.setItem('fromIndex', 'true');
+            });
+        });
+    </script>
 </body>
 </html>
 

--- a/js/includehtml.js
+++ b/js/includehtml.js
@@ -71,31 +71,41 @@
      */
     const initPasswordPrompt = () => {
         const currentPath = window.location.pathname;
+        const fromIndex = sessionStorage.getItem("fromIndex");
+        if (fromIndex) sessionStorage.removeItem("fromIndex");
+
         const requirePassword = !(
             currentPath === "/" ||
             currentPath === "/index.html" ||
             currentPath.startsWith("/html/Projects/") ||
-            currentPath === "/html/Etc/KimchiRun.html"
+            currentPath === "/html/Etc/KimchiRun.html" ||
+            fromIndex
         );
 
         if (!requirePassword) return;
 
         const passwordPrompt = document.getElementById("passwordPrompt");
         const button = document.querySelector("#passwordPrompt button");
-        if (!passwordPrompt || !button) return;
+        const input = document.getElementById("passwordInput");
+        if (!passwordPrompt || !button || !input) return;
 
         if (!sessionStorage.getItem("authenticated")) {
             passwordPrompt.style.display = "flex";
         }
 
-        button.addEventListener("click", () => {
-            const value = document.getElementById("passwordInput").value;
+        const handleConfirm = () => {
+            const value = input.value;
             if (value === "Open") {
                 sessionStorage.setItem("authenticated", "true");
                 passwordPrompt.style.display = "none";
             } else {
                 alert("비밀번호가 틀렸습니다!");
             }
+        };
+
+        button.addEventListener("click", handleConfirm);
+        input.addEventListener("keypress", (e) => {
+            if (e.key === "Enter") handleConfirm();
         });
     };
 


### PR DESCRIPTION
## Summary
- allow links from the index page to bypass password check
- hide the password prompt after successful authentication or when pressing Enter
- add helper script on the index page to mark navigation origin

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ec9cd8c648325a2569c78ad42a800