### PR TITLE
Fix default visibility of password prompt

### DIFF
--- a/css/Style1.css
+++ b/css/Style1.css
@@ -154,7 +154,7 @@ pre {
     left: 0;
     width: 100%;
     height: 100%;
-    display: flex;
+    display: none;
     justify-content: center;
     align-items: center;
     background-color: rgba(0, 0, 0, 0.8);


### PR DESCRIPTION
## Summary
- hide the `#passwordPrompt` element until the script shows it

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_684f917441448325aaa481e5b43222b3